### PR TITLE
More reliable proxy + other environments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,6 +17,7 @@ Proxy is a front-end for an unlimited number of webapps all hosted at \*.example
 ```yml
 aws:
   elb_name: proxy-elb
+  tag: proxy-web
   region: us-east-1
   ami: ami-0a313d6098716f372 # Ubuntu 18.04.2 for us-east-1
   instance_type: m3.medium
@@ -24,8 +25,28 @@ aws:
   key_name: Dave # you must upload your public key and give it a name on the EC2 dashboard
   security_group: proxy # Used for instances. Should have ports 22 and 443 open.
 env:
-  PROXY_ENV: production
   PROXY_DOMAIN: recurse.com
+  PROXY_HTTPS_PORT: 443
+  PROXY_LOG_LEVEL: info
+  PROXY_DOMAINS_ENDPOINT: https://www.example.com/domain.json
+
+  # Optional
+
+  # Remote logging over TLS. All three variables must be set.
+  # PROXY_SYSLOG_DRAIN: logs.papertrailapp.com:12345
+  # PROXY_SYSLOG_ROOT_CERTS: https://papertrailapp.com/tools/papertrail-bundle.pem
+  # PROXY_SYSLOG_PERMITTED_PEER: "*.papertrailapp.com"
+```
+
+## Example config.development.yml
+
+The development config doesn't contain the AWS section.
+
+```yml
+env:
+  PROXY_DOMAIN: recurse.com
+  PROXY_HTTPS_PORT: 8443
+  PROXY_LOG_LEVEL: debug
   PROXY_DOMAINS_ENDPOINT: https://www.example.com/domain.json
 
   # Optional

--- a/backend/bin/proxy-backend
+++ b/backend/bin/proxy-backend
@@ -6,7 +6,8 @@ begin
   Proxy.configure do |config|
     config.domain = ENV["PROXY_DOMAIN"] or raise "Missing $PROXY_DOMAIN"
     config.domains_endpoint = ENV["PROXY_DOMAINS_ENDPOINT"] or raise "Missing $PROXY_DOMAINS_ENDPOINT"
-    config.env = ENV["PROXY_ENV"] || "development"
+    config.https_port = ENV["PROXY_HTTPS_PORT"] || 8443
+    config.log_level = ENV["PROXY_LOG_LEVEL"] || "debug"
     config.delay = Integer(ENV["PROXY_DELAY"] || 15)
   end
 

--- a/backend/bin/proxy-install
+++ b/backend/bin/proxy-install
@@ -16,7 +16,7 @@ def install(dst)
   FileUtils.cp(src, dst)
 end
 
-if env == "production"
+if env != "development"
   system("apt-get install -y unattended-upgrades")
 
   install("/etc/apt/apt.conf.d/20auto-upgrades")
@@ -77,10 +77,10 @@ puts "Writing /etc/systemd/system/proxy.service"
 File.open("/etc/systemd/system/proxy.service", "w") do |f|
   vars = config["env"]
 
-  if env == 'production'
-    home_dir = '/home/ubuntu'
-  else
+  if env == 'development'
     home_dir = '/home/vagrant'
+  else
+    home_dir = '/home/ubuntu'
   end
 
   f.write systemd_erb.result(binding)

--- a/backend/bin/setup
+++ b/backend/bin/setup
@@ -2,9 +2,12 @@
 
 set -ev
 
+export DEBIAN_FRONTEND=noninteractive
+
 sleep 30
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nginx ruby
+sudo apt-get -y upgrade
+sudo apt-get install -y nginx ruby
 sudo ln -s $HOME/proxy/backend/root/etc/nginx/ssl.conf /etc/nginx/ssl.conf
 sudo ln -sf $HOME/proxy/backend/root/etc/nginx/proxy_params /etc/nginx/proxy_params
 sudo ln -s $HOME/proxy/certs/cert.pem /etc/nginx/cert.pem

--- a/backend/lib/proxy.rb
+++ b/backend/lib/proxy.rb
@@ -13,7 +13,7 @@ require_relative "proxy/nginx"
 require_relative "proxy/nginx_config"
 
 module Proxy
-  Config = Struct.new(:env, :domain, :domains_endpoint, :delay)
+  Config = Struct.new(:domain, :https_port, :log_level, :domains_endpoint, :delay)
 
   class << self
     def run
@@ -44,28 +44,15 @@ module Proxy
       yield config
     end
 
-    def development?
-      config.env == "development"
-    end
-
     def https_port
-      if development?
-        8443
-      else
-        443
-      end
+      config.https_port
     end
 
     def logger
       return @logger if defined?(@logger)
 
       @logger = Syslog::Logger.new("proxy")
-
-      if development?
-        @logger.level = Logger::DEBUG
-      else
-        @logger.level = Logger::INFO
-      end
+      @logger.level = Logger.const_get(config.log_level.upcase)
 
       @logger
     end

--- a/backend/lib/proxy.rb
+++ b/backend/lib/proxy.rb
@@ -44,15 +44,15 @@ module Proxy
       yield config
     end
 
-    def production?
-      config.env == "production"
+    def development?
+      config.env == "development"
     end
 
     def https_port
-      if production?
-        443
-      else
+      if development?
         8443
+      else
+        443
       end
     end
 
@@ -61,10 +61,10 @@ module Proxy
 
       @logger = Syslog::Logger.new("proxy")
 
-      if production?
-        @logger.level = Logger::INFO
-      else
+      if development?
         @logger.level = Logger::DEBUG
+      else
+        @logger.level = Logger::INFO
       end
 
       @logger

--- a/backend/root/etc/nginx/sites-available/default.erb
+++ b/backend/root/etc/nginx/sites-available/default.erb
@@ -15,13 +15,15 @@ server {
 		return 444;
 	}
 }
-<% mappings.each do |m| %>
+<% mappings.each_with_index do |m, i| %>
 server {
 	listen 443;
 
 	include ssl.conf;
 
 	server_name <%= m.subdomain %>.<%= domain %>;
+
+	resolver 127.0.0.53;
 
 	location / {
 		if ($http_x_forwarded_proto = "http") {
@@ -30,7 +32,8 @@ server {
 
 		include /etc/nginx/proxy_params;
 
-		proxy_pass <%= m.url %>;
+		set <%= "$host_#{i}" %> <%= m.url %>;
+		proxy_pass <%= "$host_#{i}" %>;
 	}
 }
 <% end %>

--- a/backend/root/etc/nginx/sites-available/default.erb
+++ b/backend/root/etc/nginx/sites-available/default.erb
@@ -15,7 +15,7 @@ server {
 		return 444;
 	}
 }
-<% mappings.each_with_index do |m, i| %>
+<% mappings.each do |m| %>
 server {
 	listen 443;
 
@@ -32,8 +32,8 @@ server {
 
 		include /etc/nginx/proxy_params;
 
-		set <%= "$host_#{i}" %> <%= m.url %>;
-		proxy_pass <%= "$host_#{i}" %>;
+		set $redirect_host <%= m.url %>;
+		proxy_pass $redirect_host$request_uri;
 	}
 }
 <% end %>

--- a/lib/proxy/cli.rb
+++ b/lib/proxy/cli.rb
@@ -6,14 +6,14 @@ module Proxy
       alias task define_method
     end
 
-    desc "deploy", "Deploy current master branch to Amazon AWS"
-    task "deploy" do
-      Proxy::Deploy.new.deploy
+    desc "deploy ENV", "Deploy current master branch to ENV on AWS"
+    task "deploy" do |env="production"|
+      Proxy::Deploy.new(env).deploy
     end
 
-    desc "list", "List current instances"
-    task "list" do
-      Proxy::List.new.list_instances
+    desc "list ENV", "List current instances in ENV"
+    task "list" do |env="production"|
+      Proxy::List.new(env).list_instances
     end
   end
 end

--- a/lib/proxy/cli.rb
+++ b/lib/proxy/cli.rb
@@ -8,12 +8,12 @@ module Proxy
 
     desc "deploy ENV", "Deploy current master branch to ENV on AWS"
     task "deploy" do |env="production"|
-      Proxy::Deploy.new(env).deploy
+      Proxy::Deploy.deploy(env)
     end
 
     desc "list ENV", "List current instances in ENV"
     task "list" do |env="production"|
-      Proxy::List.new(env).list_instances
+      Proxy::List.list_instances(env)
     end
   end
 end

--- a/lib/proxy/deploy.rb
+++ b/lib/proxy/deploy.rb
@@ -9,7 +9,6 @@ module Proxy
     DEPLOY_ID_FILE = Pathname.new("./.deploy")
     DEPLOY_TAG = "proxy_deploy_id"
     INSTANCE_NAME_TAG = "Name"
-    CONFIG_FILE = "config.production.yml"
     DHPARAM_FILE = "certs/dhparam.pem"
     CERT_FILE = "certs/cert.pem"
     KEY_FILE = "certs/key.pem"
@@ -17,23 +16,19 @@ module Proxy
     AUTH_POLICY_TYPE = "BackendServerAuthenticationPolicyType"
     PUBKEY_POLICY_TYPE = "PublicKeyPolicyType"
 
-    REQUIRED_FILES = [
-      CONFIG_FILE,
-      DHPARAM_FILE,
-      CERT_FILE,
-      KEY_FILE
-    ]
+    def initialize(env)
+      @env = env
 
-    def initialize
       @id = SecureRandom.uuid
 
-      aws_config = YAML.load(File.read(CONFIG_FILE))['aws']
+      aws_config = YAML.load(File.read(config_file))['aws']
 
       region = aws_config['region']
 
       # Assumes credentials in ENV or ~/.aws/credentials
       @elb = Aws::ElasticLoadBalancing::Client.new(region: region)
       @elb_name = aws_config['elb_name']
+      @tag = aws_config['tag']
 
       @ec2 = Aws::EC2::Client.new(region: region)
       @security_group = aws_config['security_group']
@@ -137,12 +132,12 @@ module Proxy
         mkdir proxy
         tar xjf #{tar_name} -C proxy
         $HOME/proxy/backend/bin/setup
-        sudo $HOME/proxy/backend/bin/proxy-install production
+        sudo $HOME/proxy/backend/bin/proxy-install #{@env}
       SHELL
     end
 
     def create_tar
-      files = `git ls-files`.split("\n") + REQUIRED_FILES
+      files = `git ls-files`.split("\n") + required_files
       system("tar cjf #{tar_name} #{files.join(' ')}")
     end
 
@@ -180,7 +175,7 @@ module Proxy
         resources: ids,
         tags: [
           {key: DEPLOY_TAG, value: @id},
-          {key: INSTANCE_NAME_TAG, value: "proxy-web"}
+          {key: INSTANCE_NAME_TAG, value: @tag}
         ]
       )
 
@@ -208,8 +203,8 @@ module Proxy
     end
 
     def ensure_necessary_files
-      unless File.exist? CONFIG_FILE
-        puts "Cannot deploy. Missing: #{CONFIG_FILE}"
+      unless File.exist? config_file
+        puts "Cannot deploy. Missing: #{config_file}"
         fail
       end
 
@@ -405,6 +400,19 @@ module Proxy
       puts "Deploy failed!"
       Process.kill(:TERM, 0)
       exit 1
+    end
+
+    def config_file
+      "config.#{@env}.yml"
+    end
+
+    def required_files
+      [
+        config_file,
+        DHPARAM_FILE,
+        CERT_FILE,
+        KEY_FILE
+      ]
     end
   end
 end

--- a/lib/proxy/deploy.rb
+++ b/lib/proxy/deploy.rb
@@ -16,6 +16,10 @@ module Proxy
     AUTH_POLICY_TYPE = "BackendServerAuthenticationPolicyType"
     PUBKEY_POLICY_TYPE = "PublicKeyPolicyType"
 
+    def self.deploy(env)
+      new(env).deploy
+    end
+
     def initialize(env)
       @env = env
 
@@ -39,6 +43,8 @@ module Proxy
     end
 
     def deploy
+      puts "Deploying #{@env}..."
+
       ensure_necessary_files
       clean_up_if_necessary
 

--- a/lib/proxy/list.rb
+++ b/lib/proxy/list.rb
@@ -2,6 +2,10 @@ require 'aws-sdk'
 
 module Proxy
   class List
+    def self.list_instances(env)
+      new(env).list_instances
+    end
+
     def initialize(env)
       @env = env
       aws_config = YAML.load(File.read(config_file))['aws']
@@ -14,6 +18,8 @@ module Proxy
     end
 
     def list_instances
+      puts "Listing #{@env}..."
+
       resp = @ec2.describe_instances(
         filters: [
           {

--- a/lib/proxy/list.rb
+++ b/lib/proxy/list.rb
@@ -2,12 +2,12 @@ require 'aws-sdk'
 
 module Proxy
   class List
-    CONFIG_FILE = "config.production.yml"
-
-    def initialize
-      aws_config = YAML.load(File.read(CONFIG_FILE))['aws']
+    def initialize(env)
+      @env = env
+      aws_config = YAML.load(File.read(config_file))['aws']
 
       region = aws_config['region']
+      @tag = aws_config['tag']
 
       # Assumes credentials in ENV or ~/.aws/credentials
       @ec2 = Aws::EC2::Client.new(region: region)
@@ -18,7 +18,7 @@ module Proxy
         filters: [
           {
             name: "tag:Name",
-            values: ["proxy-web"]
+            values: [@tag]
           },
           {
             name: "instance-state-name",
@@ -32,6 +32,10 @@ module Proxy
       instances.each do |i|
         puts "#{i[:public_dns_name]} - #{i[:state][:name]}"
       end
+    end
+
+    def config_file
+      "config.#{@env}.yml"
     end
   end
 end


### PR DESCRIPTION
- Make NGINX do DNS lookup on request rather than on boot. This should make it less likely that a bad config on recurse.com/domains crashes proxy.
- Support other environments (like staging)
- Environment settings are now entirely specified in config files:
  - No more `PROXY_ENV` or conditionals on `PROXY_ENV` in proxy-backend
  - Add `PROXY_HTTPS_PORT` and `PROXY_LOG_LEVEL`
  - Note: proxy-install still has conditional logic based on the environment passed in.